### PR TITLE
Fix css problem with <strong> tag

### DIFF
--- a/docs/readthedocs/source/_static/css/common.css
+++ b/docs/readthedocs/source/_static/css/common.css
@@ -10,7 +10,7 @@
     text-align: center;  
 }
 
-.doc-card-header > b, strong{
+.doc-card-header strong{
     font-size: 17px;
 }
 


### PR DESCRIPTION
Fix css which wrongly influence the nav bar font size and section title font size.

Test link: https://yuwentestdocs.readthedocs.io/en/restyle-readthedocs/doc/Nano/Overview/nano.html
(need to clear browser to see the change if you load this page on your browser before :D)