### PR TITLE
Remove extra styles for how-to guides

### DIFF
--- a/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
+++ b/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
@@ -4,20 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb)\n",
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb)"
    ]
   },
   {

--- a/python/chronos/colab-notebook/howto/how_to_evaluate_a_forecaster.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_evaluate_a_forecaster.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/chronos/colab-notebook/howto/how_to_evaluate_a_forecaster.ipynb)"
    ]
   },

--- a/python/chronos/colab-notebook/howto/how_to_generate_confidence_interval_for_prediction.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_generate_confidence_interval_for_prediction.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/chronos/colab-notebook/howto/how_to_generate_confidence_interval_for_prediction.ipynb)"
    ]
   },

--- a/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb)"
    ]
   },

--- a/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "\n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "\n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_pot.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_pot.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_pot.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/training/pytorch-lightning/accelerate_pytorch_lightning_training_ipex.ipynb
+++ b/python/nano/tutorial/notebook/training/pytorch-lightning/accelerate_pytorch_lightning_training_ipex.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/training/pytorch-lightning/accelerate_pytorch_lightning_training_ipex.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/training/pytorch-lightning/accelerate_pytorch_lightning_training_multi_instance.ipynb
+++ b/python/nano/tutorial/notebook/training/pytorch-lightning/accelerate_pytorch_lightning_training_multi_instance.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/training/pytorch-lightning/accelerate_pytorch_lightning_training_multi_instance.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/training/pytorch-lightning/pytorch_lightning_cv_data_pipeline.ipynb
+++ b/python/nano/tutorial/notebook/training/pytorch-lightning/pytorch_lightning_cv_data_pipeline.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/training/pytorch-lightning/pytorch_lightning_cv_data_pipeline.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/training/pytorch-lightning/pytorch_lightning_training_bf16.ipynb
+++ b/python/nano/tutorial/notebook/training/pytorch-lightning/pytorch_lightning_training_bf16.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/training/pytorch-lightning/pytorch_lightning_training_bf16.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/training/pytorch-lightning/pytorch_lightning_training_channels_last.ipynb
+++ b/python/nano/tutorial/notebook/training/pytorch-lightning/pytorch_lightning_training_channels_last.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/training/pytorch-lightning/pytorch_lightning_training_channels_last.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/training/tensorflow/accelerate_tensorflow_training_multi_instance.ipynb
+++ b/python/nano/tutorial/notebook/training/tensorflow/accelerate_tensorflow_training_multi_instance.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/training/tensorflow/accelerate_tensorflow_training_multi_instance.ipynb)"
    ]
   },

--- a/python/nano/tutorial/notebook/training/tensorflow/tensorflow_training_embedding_sparseadam.ipynb
+++ b/python/nano/tutorial/notebook/training/tensorflow/tensorflow_training_embedding_sparseadam.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<style>\n",
-    "    .rst-content blockquote {\n",
-    "        margin-left: 0px;\n",
-    "    }\n",
-    "    \n",
-    "    blockquote > div {\n",
-    "        margin: 1.5625em auto;\n",
-    "        padding: 20px 15px 1px;\n",
-    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
-    "        border-radius: 0.2rem;\n",
-    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
-    "    }\n",
-    "</style>\n",
-    "\n",
     "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/training/tensorflow/tensorflow_training_embedding_sparseadam.ipynb)"
    ]
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove extra styles for special boxes (note, warning, etc.) in Nano & Chronos how-to guides

- Before
  ![image](https://user-images.githubusercontent.com/54161268/195294808-fa882bd2-0ffc-41d6-bc5a-90131af22ae8.png)

- After
  ![image](https://user-images.githubusercontent.com/54161268/195295185-716204b3-5c08-4a35-8f4f-2aa27eb6cfd0.png)


## How was this patch tested?

Document test:
- Nano how-to: https://yuwentestdocs.readthedocs.io/en/remove-howto-styles/doc/Nano/Howto/index.html
- Chronos how-to: https://yuwentestdocs.readthedocs.io/en/remove-howto-styles/doc/Chronos/Howto/index.html

## Related links or issues (optional)
https://github.com/analytics-zoo/bigdl-v2-doc/issues/17

