### PR TITLE
Remove theme-specific style config for card components

### DIFF
--- a/docs/readthedocs/source/doc/Chronos/Overview/quick-tour.rst
+++ b/docs/readthedocs/source/doc/Chronos/Overview/quick-tour.rst
@@ -6,10 +6,6 @@ Welcome to Chronos for building a fast, accurate and scalable time series analys
 
     .. grid-item-card::
         :text-align: center
-        :shadow: none
-        :class-header: sd-bg-light
-        :class-footer: sd-bg-light
-        :class-card: sd-mb-2
 
         **Data processing**
         ^^^
@@ -22,13 +18,11 @@ Welcome to Chronos for building a fast, accurate and scalable time series analys
 
             Get Started
 
-.. grid:: 1 1 3 3
+.. grid:: 1 3 3 3
+    :gutter: 2
 
     .. grid-item-card::
         :text-align: center
-        :shadow: none
-        :class-header: sd-bg-light
-        :class-footer: sd-bg-light
         :class-card: sd-mb-2
 
         **Forecasting**
@@ -44,9 +38,6 @@ Welcome to Chronos for building a fast, accurate and scalable time series analys
 
     .. grid-item-card::
         :text-align: center
-        :shadow: none
-        :class-header: sd-bg-light
-        :class-footer: sd-bg-light
         :class-card: sd-mb-2
 
         **Anomaly Detection**
@@ -62,9 +53,6 @@ Welcome to Chronos for building a fast, accurate and scalable time series analys
 
     .. grid-item-card::
         :text-align: center
-        :shadow: none
-        :class-header: sd-bg-light
-        :class-footer: sd-bg-light
         :class-card: sd-mb-2
 
         **Simulation**
@@ -104,7 +92,7 @@ In Chronos, we provide a ``TSDataset`` (and a ``XShardsTSDataset`` to handle lar
 
 
 .. grid:: 2
-    :gutter: 1
+    :gutter: 2
 
     .. grid-item-card::
 
@@ -192,7 +180,7 @@ For time series forecasting, we also provide an ``AutoTSEstimator`` for distribu
         stop_orca_context()
 
 .. grid:: 3
-    :gutter: 1
+    :gutter: 2
 
     .. grid-item-card::
 
@@ -246,7 +234,7 @@ To import a specific detector, you may use {algorithm name} + "Detector", and ca
         anomaly_indexes = detector.anomaly_indexes()
 
 .. grid:: 3
-    :gutter: 1
+    :gutter: 2
 
     .. grid-item-card::
 
@@ -280,7 +268,7 @@ Simulator(experimental)
 Simulator is still under activate development with unstable API.
 
 .. grid:: 2
-    :gutter: 1
+    :gutter: 2
 
     .. grid-item-card::
 

--- a/docs/readthedocs/source/doc/Chronos/index.rst
+++ b/docs/readthedocs/source/doc/Chronos/index.rst
@@ -6,11 +6,10 @@ BigDL-Chronos
 You can use **Chronos** for:
 
 
-.. grid:: 3
-    :gutter: 1
+.. grid:: 1 3 3 3
+    :gutter: 2
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Forecasting**
         ^^^
@@ -24,7 +23,6 @@ You can use **Chronos** for:
         Predict future using history data.
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Anomaly Detection**
         ^^^
@@ -38,7 +36,6 @@ You can use **Chronos** for:
         Discover unexpected items in data.
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Simulation**
         ^^^
@@ -55,11 +52,10 @@ You can use **Chronos** for:
 -------
 
 
-.. grid:: 2
-    :gutter: 1
+.. grid:: 1 2 2 2
+    :gutter: 2
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Get Started**
         ^^^
@@ -71,7 +67,6 @@ You can use **Chronos** for:
         `Installation <./Overview/install.html>`_
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Key Features Guide**
         ^^^
@@ -85,11 +80,7 @@ You can use **Chronos** for:
         `Detect <./Overview/anomaly_detection.html>`_ /
         `Simulate <./Overview/simulation.html>`_
 
-.. grid:: 2
-    :gutter: 1
-
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **How-to-Guide** / **Tutorials**
         ^^^
@@ -102,7 +93,6 @@ You can use **Chronos** for:
         `How-to-Guide <./Howto/index.html>`_ / `Example <./QuickStart/index.html>`_
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **API Document**
         ^^^

--- a/docs/readthedocs/source/doc/DLlib/index.rst
+++ b/docs/readthedocs/source/doc/DLlib/index.rst
@@ -6,11 +6,10 @@ BigDL-DLlib
 -------
 
 
-.. grid:: 2
-    :gutter: 1
+.. grid:: 1 2 2 2
+    :gutter: 2
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Get Started**
         ^^^
@@ -22,7 +21,6 @@ BigDL-DLlib
         `Installation <./Overview/install.html>`_ /
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Key Features Guide**
         ^^^
@@ -34,11 +32,7 @@ BigDL-DLlib
         `Keras-Like API <./Overview/keras-api.html>`_ /
         `Spark ML Pipeline <./Overview/nnframes.html>`_ /
 
-.. grid:: 2
-    :gutter: 1
-
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Examples**
         ^^^
@@ -51,7 +45,6 @@ BigDL-DLlib
         `Tutorials <./QuickStart/index.html>`_
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **API Document**
         ^^^

--- a/docs/readthedocs/source/doc/Nano/index.rst
+++ b/docs/readthedocs/source/doc/Nano/index.rst
@@ -6,11 +6,10 @@ BigDL-Nano
 -------
 
 
-.. grid:: 2
-    :gutter: 1
+.. grid:: 1 2 2 2
+    :gutter: 2
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Get Started**
         ^^^
@@ -23,7 +22,6 @@ BigDL-Nano
         `Tutorials <./QuickStart/index.html>`_
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Key Features Guide**
         ^^^
@@ -37,11 +35,7 @@ BigDL-Nano
         `Tensorflow Inference <./Overview/tensorflow_inference.html>`_ /
         `Tensorflow Training <./Overview/tensorflow_train.html>`_
 
-.. grid:: 2
-    :gutter: 1
-
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **How-to Guide**
         ^^^
@@ -54,7 +48,6 @@ BigDL-Nano
         `How-to-Guide <./Howto/index.html>`_
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **API Document**
         ^^^

--- a/docs/readthedocs/source/doc/Orca/index.rst
+++ b/docs/readthedocs/source/doc/Orca/index.rst
@@ -7,11 +7,10 @@ Most AI projects start with a Python notebook running on a single laptop; howeve
 -------
 
 
-.. grid:: 2
-    :gutter: 1
+.. grid:: 1 2 2 2
+    :gutter: 2
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Get Started**
         ^^^
@@ -24,7 +23,6 @@ Most AI projects start with a Python notebook running on a single laptop; howeve
         `Tutorials <./QuickStart/index.html>`_
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **Key Features Guide**
         ^^^
@@ -38,11 +36,7 @@ Most AI projects start with a Python notebook running on a single laptop; howeve
         `Distributed Training and Inference <./Overview/distributed-training-inference.html>`_ /
         `Distributed AutoML <./Overview/distributed-tuning.html>`_
 
-.. grid:: 2
-    :gutter: 1
-
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **How-to Guide**
         ^^^
@@ -55,7 +49,6 @@ Most AI projects start with a Python notebook running on a single laptop; howeve
         `How-to-Guide <./Howto/index.html>`_
 
     .. grid-item-card::
-        :class-footer: sd-bg-light
 
         **API Document**
         ^^^


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make card components generated by sphinx-design look normal in our document

## How was this patch tested?

Document test: https://yuwentestdocs.readthedocs.io/en/restyle-card-component/doc/Orca/index.html

## Related links or issues (optional)
https://github.com/analytics-zoo/bigdl-v2-doc/issues/17

